### PR TITLE
Social Login Without Internationalization fails

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/social/_social.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/social/_social.component.ts
@@ -21,7 +21,9 @@ export class <%=jhiPrefixCapitalized%>SocialComponent implements OnInit {
     ) {}
 
     ngOnInit() {
+        <%_ if (enableTranslation) { _%>
         this.languageService.addLocation('social');
+        <%_ } _%>
         this.label = this.provider.charAt(0).toUpperCase() + this.provider.slice(1);
         this.providerSetting = this.socialService.getProviderSetting(this.provider);
         this.providerURL = this.socialService.getProviderURL(this.provider);


### PR DESCRIPTION
Added a check for translations being enabled before adding a location to the language service, otherwise builds fail with the error

```
ERROR in [at-loader] src/main/webapp/app/shared/social/social.component.ts:22:14
    Property 'languageService' does not exist on type 'JhiSocialComponent'.
```

See #5061 for bug report
